### PR TITLE
Add test for boolean keys

### DIFF
--- a/test/config.yaml
+++ b/test/config.yaml
@@ -4,3 +4,5 @@ port: 8080
 person:
   name: Brian
   alias: cpsubrian
+optimize: false
+turbo: true

--- a/test/yaml.js
+++ b/test/yaml.js
@@ -14,6 +14,8 @@ describe('YAML etc plugin', function() {
     conf.file(path.join(__dirname, 'config.yaml'));
     assert.equal(conf.get('host'), 'localhost');
     assert.equal(conf.get('person:name'), 'Brian');
+    assert.strictEqual(conf.get('optimize'), false);
+    assert.strictEqual(conf.get('turbo'), true);
   });
 
 });


### PR DESCRIPTION
I thought the YAML spec said you could do "Yes", "no", etc., but looks like the node parser only supports "true" and "false"
